### PR TITLE
Fix the native build 

### DIFF
--- a/mpinsdk/build.gradle
+++ b/mpinsdk/build.gradle
@@ -19,7 +19,7 @@ android {
         externalNativeBuild {
             cmake {
                 arguments '-DANDROID_TOOLCHAIN=clang',
-                          '-DANDROID_STL=gnustl_static'
+                          '-DANDROID_STL=c++_static'
                 cppFlags "-fexceptions -std=c++11"
             }
         }


### PR DESCRIPTION
Update the -DANDROID_STL to c++_static, because gnustl_static is deprecated.